### PR TITLE
Ensure we form the URI correctly

### DIFF
--- a/generated/unique-id/Endpoint/GetUniqueId.php
+++ b/generated/unique-id/Endpoint/GetUniqueId.php
@@ -11,7 +11,7 @@ class GetUniqueId extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
     }
     public function getUri() : string
     {
-        return '/unique-id';
+        return 'unique-id';
     }
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
     {

--- a/src/getUniqueId.php
+++ b/src/getUniqueId.php
@@ -11,8 +11,8 @@ class SDGClient extends GeneratedClient {
         $apiKey = getenv('SDGAPIKEY');
         $authenticationRegistry = new AuthenticationRegistry([new ApiKeyAuthentication($apiKey)]);
         $client = new Client([
-            'base_uri' => 'https://collect.sdgacceptance.eu/1.0.0/',
-//            'base_uri' => 'https://collect.youreurope.ec.europa.eu/1.0.0',
+            'base_uri' => 'https://collect.sdgacceptance.eu/v1/',
+//            'base_uri' => 'https://collect.youreurope.ec.europa.eu/v1',
         ]);
         $httpClient = new \Http\Client\Common\PluginClient($client, [$authenticationRegistry]);
         return parent::create($httpClient);


### PR DESCRIPTION
The version shoudl be v1 instead of 1.0.0 and the leading / in the path
caused guzzle to drop the v1 part, so remove that.